### PR TITLE
Add test-unit gem dependency explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
 - 2.0.0
+- 2.1
+- 2.2
 script:
 - bundle install
 - bundle exec rake

--- a/fluent-plugin-elb-access-log.gemspec
+++ b/fluent-plugin-elb-access-log.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'test-unit', '>= 3.1.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,3 +38,7 @@ region #{region}
   tag = options[:tag] || 'test.default'
   Fluent::Test::OutputTestDriver.new(Fluent::ElbAccessLogInput, tag).configure(fluentd_conf)
 end
+
+# prevent Test::Unit's AutoRunner from executing during RSpec's rake task
+# ref: https://github.com/rspec/rspec-rails/issues/1171
+Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.