### PR TITLE
Support secret parameter feature

### DIFF
--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -32,8 +32,8 @@ class Fluent::ElbAccessLogInput < Fluent::Input
     define_method('router') { Fluent::Engine }
   end
 
-  config_param :aws_key_id,        :string,  :default => nil
-  config_param :aws_sec_key,       :string,  :default => nil
+  config_param :aws_key_id,        :string,  :default => nil, :secret => true
+  config_param :aws_sec_key,       :string,  :default => nil, :secret => true
   config_param :profile,           :string,  :default => nil
   config_param :credentials_path,  :string,  :default => nil
   config_param :http_proxy,        :string,  :default => nil


### PR DESCRIPTION
`aws_key_id` and `aws_sec_key` contain sensitive information.
These parameters should be concealed with secret parameter feature.