### PR TITLE
Add a missing require for v0.14 compat layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-- 2.0.0
 - 2.1
 - 2.2
+- 2.3.4
+- 2.4.1
 script:
 - bundle install
 - bundle exec rake

--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 require 'fluent_plugin_elb_access_log/version'
 
 class Fluent::ElbAccessLogInput < Fluent::Input


### PR DESCRIPTION
To work with v0.14 compatible layer, we should require `'fluent/input'` explicitly.
Otherwise, the following error occurs:

```log
% bundle exec rake spec 
~/.rbenv/versions/2.4.1/bin/ruby -I$HOME/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib:$HOME/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.6.0/lib $HOME/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
~/GitHub/fluent-plugin-elb-access-log/lib/fluent/plugin/in_elb_access_log.rb:3:in `<top (required)>': uninitialized constant Fluent::Input (NameError)
	from ~/GitHub/fluent-plugin-elb-access-log/spec/spec_helper.rb:2:in `require'
	from ~/GitHub/fluent-plugin-elb-access-log/spec/spec_helper.rb:2:in `<top (required)>'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1453:in `require'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1453:in `block in requires='
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1453:in `each'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1453:in `requires='
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:111:in `each'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:21:in `configure'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:99:in `setup'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:86:in `run'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
	from ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/exe/rspec:4:in `<main>'
~/.rbenv/versions/2.4.1/bin/ruby -I$HOME/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib:~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.6.0/lib ~/GitHub/fluent-plugin-elb-access-log/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```