### PR TITLE
Compatibility with fluentd 0.14

### DIFF
--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -1,4 +1,5 @@
 require 'fluent_plugin_elb_access_log/version'
+require 'fluent/input'
 
 class Fluent::ElbAccessLogInput < Fluent::Input
   Fluent::Plugin.register_input('elb_access_log', self)


### PR DESCRIPTION
I got the following error with fluentd 0.14.15 and this PR can fix this problem,

```
2017-05-17 08:52:47 +0000 [error]: #0 unexpected error error_class=NameError error="uninitialized constant Fluent::Input"
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-elb-access-log-0.3.3/lib/fluent/plugin/in_elb_access_log.rb:3:in `<top (required)>'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/registry.rb:102:in `block in search'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/registry.rb:99:in `each'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/registry.rb:99:in `search'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/registry.rb:44:in `lookup'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/plugin.rb:146:in `new_impl'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/plugin.rb:100:in `new_input'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/root_agent.rb:265:in `add_source'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/root_agent.rb:119:in `block in configure'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/root_agent.rb:115:in `each'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/root_agent.rb:115:in `configure'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/engine.rb:127:in `configure'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/engine.rb:92:in `run_configure'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/supervisor.rb:733:in `run_configure'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/supervisor.rb:502:in `block in run_worker'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/supervisor.rb:661:in `call'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/supervisor.rb:661:in `main_process'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/supervisor.rb:498:in `run_worker'
  2017-05-17 08:52:47 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.14.15/lib/fluent/command/fluentd.rb:316:in `<main>'
```

@winebarrel Could you review this PR and release new version?