### PR TITLE
Normalize line feeds in user-agent

### DIFF
--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -166,7 +166,7 @@ class Fluent::ElbAccessLogInput < Fluent::Input
 
     parsed_access_log = []
 
-    access_log.split("\n").each do |line|
+    normalize_line_feeds(access_log).split("\n").each do |line|
       line = parse_line(line)
       parsed_access_log << line if line
     end
@@ -213,6 +213,32 @@ class Fluent::ElbAccessLogInput < Fluent::Input
     end
 
     parsed
+  end
+
+  # This method is required because fields of user-agent are sometimes separated
+  # to several lines like flollowing example,
+  # 2017-06-07T22:47:14.827494Z baby 162.243.126.163:37036 10.6.49.1:80 0.000042 0.004133 0.00002 301 301 0 232 "GET http://example.com:80/ HTTP/1.0" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133
+  #          Safari/537.36
+  #" - -
+  def normalize_line_feeds(str)
+    in_quotation = false
+    normalized_str = ''
+    previous_ch = nil
+
+    str.each_char do |current_ch|
+      if in_quotation && current_ch == "\n"
+        normalized_str << ' '
+      else
+        normalized_str << current_ch
+      end
+
+      if current_ch == '"' && previous_ch != '"'
+        in_quotation = !in_quotation
+      end
+      previous_ch = current_ch
+    end
+
+    normalized_str
   end
 
   def sampling(access_log)

--- a/spec/in_elb_access_log_spec.rb
+++ b/spec/in_elb_access_log_spec.rb
@@ -678,4 +678,68 @@ describe Fluent::ElbAccessLogInput do
 
     it { is_expected.to eq expected_emits }
   end
+
+  context 'when a record has a line feed in an user-agent quotation' do
+    let(:today_access_log) do
+      <<-'EOS'
+2015-05-24T19:55:36.000000Z hoge 14.14.124.20:57673 10.0.199.184:80 0.000053 0.000913 0.000036 200 200 0 3 "GET http://hoge-1876938939.ap-northeast-1.elb.amazonaws.com:80/ HTTP/1.1" "Dummy user agent
+   ""7.30.0""
+  - " ssl_cipher ssl_protocol
+      EOS
+    end
+
+    before do
+      expect(client).to receive(:list_objects).with(bucket: s3_bucket, prefix: yesterday_prefix) { [] }
+      expect(client).to receive(:list_objects).with(bucket: s3_bucket, prefix: tomorrow_prefix) { [] }
+
+      expect(client).to receive(:list_objects).with(bucket: s3_bucket, prefix: today_prefix) do
+        [double('today_objects', contents: [double('today_object', key: today_object_key)])]
+      end
+
+      expect(client).to receive(:get_object).with(bucket: s3_bucket, key: today_object_key) do
+        double('today_s3_object', body: StringIO.new(today_access_log))
+      end
+
+      expect(driver.instance).to receive(:save_timestamp).with(today)
+      expect(driver.instance).to receive(:save_history)
+
+      driver.run
+    end
+
+    let(:expected_emits) do
+      [["elb.access_log",
+        Time.parse('2015-05-24 19:55:36 UTC').to_i,
+        {"timestamp"=>"2015-05-24T19:55:36.000000Z",
+         "elb"=>"hoge",
+         "client"=>"14.14.124.20",
+         "client_port"=>57673,
+         "backend"=>"10.0.199.184",
+         "backend_port"=>80,
+         "request_processing_time"=>5.3e-05,
+         "backend_processing_time"=>0.000913,
+         "response_processing_time"=>3.6e-05,
+         "elb_status_code"=>200,
+         "backend_status_code"=>200,
+         "received_bytes"=>0,
+         "sent_bytes"=>3,
+         "request"=>
+          "GET http://hoge-1876938939.ap-northeast-1.elb.amazonaws.com:80/ HTTP/1.1",
+         "user_agent"=>'Dummy user agent "7.30.0" - ',
+         "ssl_cipher"=>"ssl_cipher",
+         "ssl_protocol"=>"ssl_protocol",
+         "request.method"=>"GET",
+         "request.uri"=>
+          "http://hoge-1876938939.ap-northeast-1.elb.amazonaws.com:80/",
+         "request.http_version"=>"HTTP/1.1",
+         "request.uri.scheme"=>"http",
+         "request.uri.user"=>nil,
+         "request.uri.host"=>"hoge-1876938939.ap-northeast-1.elb.amazonaws.com",
+         "request.uri.port"=>80,
+         "request.uri.path"=>"/",
+         "request.uri.query"=>nil,
+         "request.uri.fragment"=>nil}]]
+    end
+
+    it { is_expected.to eq expected_emits }
+  end
 end


### PR DESCRIPTION
Sometimes ELBs generate like following logs,

```
2017-06-07T22:47:14.827494Z baby 162.243.126.163:37036 10.6.49.1:80 0.000042 0.004133 0.00002 301 301 0 232 "GET http://example.com:80/ HTTP/1.0" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133
          Safari/537.36
" - -
```

It causes errors to parse timestamps. So this change normalize `\n` (line feed) between quotations.