### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -1,3 +1,9 @@
+require 'csv'
+require 'fileutils'
+require 'logger'
+require 'time'
+require 'addressable/uri'
+require 'aws-sdk'
 require 'fluent/input'
 require 'fluent_plugin_elb_access_log/version'
 
@@ -54,12 +60,6 @@ class Fluent::Plugin::ElbAccessLogInput < Fluent::Plugin::Input
 
   def initialize
     super
-    require 'csv'
-    require 'fileutils'
-    require 'logger'
-    require 'time'
-    require 'addressable/uri'
-    require 'aws-sdk'
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -31,14 +31,6 @@ class Fluent::Plugin::ElbAccessLogInput < Fluent::Plugin::Input
     'ssl_protocol'             => nil,
   }
 
-  unless method_defined?(:log)
-    define_method('log') { $log }
-  end
-
-  unless method_defined?(:router)
-    define_method('router') { Fluent::Engine }
-  end
-
   config_param :aws_key_id,        :string,  :default => nil, :secret => true
   config_param :aws_sec_key,       :string,  :default => nil, :secret => true
   config_param :profile,           :string,  :default => nil
@@ -57,10 +49,6 @@ class Fluent::Plugin::ElbAccessLogInput < Fluent::Plugin::Input
   config_param :history_length,    :integer, :default => 100
   config_param :sampling_interval, :integer, :default => 1
   config_param :debug,             :bool,    :default => false
-
-  def initialize
-    super
-  end
 
   def configure(conf)
     super

--- a/lib/fluent/plugin/in_elb_access_log.rb
+++ b/lib/fluent/plugin/in_elb_access_log.rb
@@ -1,7 +1,7 @@
 require 'fluent/input'
 require 'fluent_plugin_elb_access_log/version'
 
-class Fluent::ElbAccessLogInput < Fluent::Input
+class Fluent::Plugin::ElbAccessLogInput < Fluent::Plugin::Input
   Fluent::Plugin.register_input('elb_access_log', self)
 
   USER_AGENT_SUFFIX = "fluent-plugin-elb-access-log/#{FluentPluginElbAccessLog::VERSION}"
@@ -113,6 +113,7 @@ class Fluent::ElbAccessLogInput < Fluent::Input
   def shutdown
     @loop.stop
     @thread.join
+    super
   end
 
   private

--- a/spec/in_elb_access_log_config_spec.rb
+++ b/spec/in_elb_access_log_config_spec.rb
@@ -11,8 +11,8 @@ describe 'Fluent::ElbAccessLogInput#configure' do
     Timecop.freeze(today)
     allow(FileUtils).to receive(:touch)
     allow(File).to receive(:read) { nil }
-    allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:load_history) { [] }
-    allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:parse_tsfile) { nil }
+    allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:load_history) { [] }
+    allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:parse_tsfile) { nil }
   end
 
   context 'when default' do
@@ -136,7 +136,7 @@ describe 'Fluent::ElbAccessLogInput#configure' do
     end
 
     before do
-      allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:parse_tsfile) { Time.parse(tsfile_datetime) }
+      allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:parse_tsfile) { Time.parse(tsfile_datetime) }
     end
 
     it do
@@ -158,7 +158,7 @@ describe 'Fluent::ElbAccessLogInput#configure' do
     end
 
     before do
-      allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:parse_tsfile) { Time.parse(tsfile_datetime) }
+      allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:parse_tsfile) { Time.parse(tsfile_datetime) }
       allow_any_instance_of(Fluent::Test::TestLogger).to receive(:warn).with("start_datetime(#{start_datetime}) is set. but tsfile datetime(#{tsfile_datetime}) is used")
     end
 

--- a/spec/in_elb_access_log_spec.rb
+++ b/spec/in_elb_access_log_spec.rb
@@ -1,4 +1,4 @@
-describe Fluent::ElbAccessLogInput do
+describe Fluent::Plugin::ElbAccessLogInput do
   let(:account_id) { '123456789012' }
   let(:s3_bucket) { 'my-bucket' }
   let(:region) { 'us-west-1' }
@@ -28,9 +28,9 @@ describe Fluent::ElbAccessLogInput do
 
   before do
     Timecop.freeze(today)
-    allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:client) { client }
-    allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:load_history) { [] }
-    allow_any_instance_of(Fluent::ElbAccessLogInput).to receive(:parse_tsfile) { nil }
+    allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:client) { client }
+    allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:load_history) { [] }
+    allow_any_instance_of(Fluent::Plugin::ElbAccessLogInput).to receive(:parse_tsfile) { nil }
     allow(FileUtils).to receive(:touch)
   end
 
@@ -38,7 +38,7 @@ describe Fluent::ElbAccessLogInput do
     Timecop.return
   end
 
-  subject { x = driver.emits; x }
+  subject { x = driver.events; x }
 
   context 'when access log does not exist' do
     before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_elb_access_log'
 
 require 'aws-sdk'
@@ -36,7 +37,7 @@ region #{region}
   EOS
 
   tag = options[:tag] || 'test.default'
-  Fluent::Test::OutputTestDriver.new(Fluent::ElbAccessLogInput, tag).configure(fluentd_conf)
+  Fluent::Test::Driver::Input.new(Fluent::Plugin::ElbAccessLogInput).configure(fluentd_conf)
 end
 
 # prevent Test::Unit's AutoRunner from executing during RSpec's rake task


### PR DESCRIPTION
I've tried to migrate to use v0.14 Input Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

For future work, timer plugin helper might be usable this plugin:
http://www.clear-code.com/blog/2016/8/30.html

Thanks in advance.